### PR TITLE
Change return-type of annotated endpoint to Respons

### DIFF
--- a/flask_pydantic_api/__init__.py
+++ b/flask_pydantic_api/__init__.py
@@ -1,2 +1,7 @@
 from .api_wrapper import pydantic_api  # noqa: F401
 from .utils import UploadedFile  # noqa: F401
+
+__all__ = [
+    "pydantic_api", 
+    "UploadedFile",
+]

--- a/flask_pydantic_api/api_wrapper.py
+++ b/flask_pydantic_api/api_wrapper.py
@@ -2,9 +2,10 @@ from concurrent.futures import ThreadPoolExecutor
 from functools import wraps
 from inspect import isclass
 from itertools import chain
-from typing import Any, Callable, Dict, List, Optional, ParamSpec, Tuple, Type, TypeVar, get_origin
+from typing import Any, Awaitable, Callable, Dict, List, Optional, ParamSpec, Tuple, Type, TypeVar, get_origin
 
 from flask import Response, abort, current_app, jsonify, make_response, request
+from flask.typing import ResponseReturnValue
 from pydantic import BaseModel, ConfigDict, TypeAdapter, ValidationError
 
 from .utils import (
@@ -121,6 +122,9 @@ def get_request_args(
     return args, view_kwargs, request_model
 
 
+EndpointReturnValue = ResponseReturnValue | BaseModel | Awaitable[ResponseReturnValue | BaseModel]
+
+
 # decorator that can be composed with regular Flask @blueprint.get/post/etc decorators.
 # This decorator uses type signatures to figure out the request and response pydantic models.
 def pydantic_api(
@@ -134,8 +138,8 @@ def pydantic_api(
     openapi_schema_extra: Optional[Dict[str, Any]] = None,
     model_dump_kwargs: Optional[Dict[str, Any]] = None,
     get_request_model_from_query_string: Optional[bool] = False,
-) -> Callable[[Callable[P, Any]], Callable[P, Response]]:
-    def wrap(view_func: Callable[P, Any]) -> Callable[P, Response]:
+) -> Callable[[Callable[P, EndpointReturnValue | Awaitable[EndpointReturnValue]]], Callable[P, Response]]:
+    def wrap(view_func: Callable[P, EndpointReturnValue | Awaitable[EndpointReturnValue]]) -> Callable[P, Response]:
         request_model_param_name, request_models, response_models = (
             get_annotated_models(view_func)
         )

--- a/flask_pydantic_api/api_wrapper.py
+++ b/flask_pydantic_api/api_wrapper.py
@@ -27,7 +27,6 @@ except ImportError:
 
 
 P = ParamSpec("P")
-T = TypeVar("T")
 DT = TypeVar("DT", bound=Dict[str, Any])
 
 
@@ -136,7 +135,7 @@ def pydantic_api(
     model_dump_kwargs: Optional[Dict[str, Any]] = None,
     get_request_model_from_query_string: Optional[bool] = False,
 ) -> Callable[[Callable[P, Any]], Callable[P, Response]]:
-    def wrap(view_func: Callable[P, T]) -> Callable[P, Response]:
+    def wrap(view_func: Callable[P, Any]) -> Callable[P, Response]:
         request_model_param_name, request_models, response_models = (
             get_annotated_models(view_func)
         )
@@ -217,7 +216,10 @@ def pydantic_api(
                             result.__class__, success_status_code
                         )
 
-                    result = make_response(result_data, status_code)
+                    response = make_response(result_data, status_code)
+
+                else:
+                    response = make_response(result)
 
             except ValidationError as e:
                 raise Exception(
@@ -226,7 +228,7 @@ def pydantic_api(
                     f"error: {str(e)}"
                 )
 
-            return result
+            return response
 
         # Normally wrapping functions with decorators leaves no easy
         # way to tell who is doing the wrapping and for what purpose.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,9 @@
 [build-system]
 requires = ["setuptools>=58", "wheel"]
 build-backend = "setuptools.build_meta"
+
+[tool.pytest.ini_options]
+# https://docs.pytest.org/en/stable/reference/reference.html#ini-options-ref
+testpaths = ["tests"]
+pythonpath = ["."]
+verbosity_assertions = 2

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Internet
 
-python_requires = >= 3.8
+python_requires = >= 3.10
 
 [options]
 packages = flask_pydantic_api


### PR DESCRIPTION
Addresses #5

Before this change, pyright will emit errors such as:
```
.../views.py:42:2 - error: Argument of type "(scenario_id: int) -> CompleteScenario" cannot be assigned to parameter of type "T_route@route"
```

This requires usage of `ParamSpec` which was introduced in python 3.10 so lifts the python requirements. There may be a way to keep backwards compatible through `type_extensions` or simpler fall-backs but static type checkers don't like those kinds of games so I'm not quite sure it'd work. 

The decorator is quite permissive in that it passes through any value which isn't either a `BaseModel` or a dict. This leads to quite loose typing of the input and in order for the whole thing not to explode into overload cases (which I'm not sure I could code up) I made the decorated function always return `Response`.

It could be argued that it doesn't make sense to apply this decorator to functions other than those returning `BaseModel` or `dict` (or lists if the decorator learns how to use `TypeDecorator`) and the type could be tightened to reflect that.
