### PR TITLE
fix(serializer): fix multiple errors ocurring without the `serializer` extra

### DIFF
--- a/flask_pydantic_api/openapi.py
+++ b/flask_pydantic_api/openapi.py
@@ -13,17 +13,20 @@ from .utils import get_annotated_models, model_has_uploaded_file_type
 HTTP_METHODS = set(["get", "post", "patch", "delete", "put"])
 
 model_has_fieldsets_defined: Optional[Callable] = None
+DEFAULT_SCHEMA_GENERATOR: type[GenerateJsonSchema] = GenerateJsonSchema
+
 try:
     from pydantic_enhanced_serializer.schema import (
         FieldsetGenerateJsonSchema,
         model_has_fieldsets_defined,
     )
+    DEFAULT_SCHEMA_GENERATOR = FieldsetGenerateJsonSchema
 except ImportError:
-    model_has_fieldsets_defined = None
+    pass
 
 
 def get_pydantic_api_path_operations(
-    schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
+    schema_generator: type[GenerateJsonSchema] = DEFAULT_SCHEMA_GENERATOR,
 ) -> Tuple[Dict[str, Any], Dict[str, Any]]:
     paths: Dict[str, dict] = defaultdict(dict)
     components: Dict[str, dict] = {}
@@ -244,7 +247,7 @@ def add_response_schema(
     openapi: Dict[str, Any],
     status_code: str,
     model: Type[BaseModel],
-    schema_generator: type[GenerateJsonSchema] = GenerateJsonSchema,
+    schema_generator: type[GenerateJsonSchema] = DEFAULT_SCHEMA_GENERATOR,
 ) -> Dict[str, Any]:
     if not openapi.get("paths"):
         return openapi
@@ -288,11 +291,8 @@ def add_response_schema(
 
 
 def get_openapi_schema(
-    schema_generator: Optional[type[GenerateJsonSchema]] = None, **kwargs
+    schema_generator: type[GenerateJsonSchema] = DEFAULT_SCHEMA_GENERATOR, **kwargs
 ) -> Dict[str, Any]:
-    if schema_generator is None and FieldsetGenerateJsonSchema is not None:
-        schema_generator = FieldsetGenerateJsonSchema
-
     paths, components = get_pydantic_api_path_operations(
         schema_generator=schema_generator
     )

--- a/setup.cfg
+++ b/setup.cfg
@@ -19,7 +19,7 @@ classifiers =
     Topic :: Software Development :: Libraries :: Python Modules
     Topic :: Internet
 
-python_requires = >= 3.8
+python_requires = >= 3.9
 
 [options]
 packages = flask_pydantic_api
@@ -49,7 +49,7 @@ dev =
 flask_pydantic_api = py.typed, templates/*.html
 
 [tool:pytest]
-addopts = --cov=flask_pydantic_api --no-cov-on-fail -s
+addopts = --cov=flask_pydantic_api --no-cov-on-fail
 
 [coverage:report]
 fail_under: 85

--- a/tests/test_api_wrapper.py
+++ b/tests/test_api_wrapper.py
@@ -7,6 +7,8 @@ from pytest_mock.plugin import MockerFixture
 
 from flask_pydantic_api import pydantic_api
 
+from tests.utils import has_enhanced_serializer
+
 
 @pytest.mark.parametrize("with_enhanced_serializer", [False, True])
 def test_simple_response(mocker: MockerFixture, with_enhanced_serializer: bool) -> None:
@@ -321,7 +323,7 @@ def test_fields_in_signature() -> None:
     @app.get("/")
     @pydantic_api()
     def do_work(fields: List[str]) -> Response:
-        assert fields == ["a", "b", "c.d"]
+        assert fields == (["a", "b", "c.d"] if has_enhanced_serializer else [])
 
         return Response(
             field1="field1 value",
@@ -349,7 +351,7 @@ def test_post_fields_in_signature() -> None:
     @app.post("/")
     @pydantic_api()
     def do_work(fields: List[str]) -> Response:
-        assert fields == ["a", "b", "c.d"]
+        assert fields == (["a", "b", "c.d"] if has_enhanced_serializer else [])
 
         return Response(
             field1="field1 value",

--- a/tests/test_enhanced_serializer.py
+++ b/tests/test_enhanced_serializer.py
@@ -2,9 +2,17 @@ from typing import Any, ClassVar
 
 from flask import Flask
 from pydantic import BaseModel
-from pydantic_enhanced_serializer import FieldsetConfig, ModelExpansion
+
+from tests.utils import require_serializer
+
+try:  # Ensure pytest can parse the file without the import
+    from pydantic_enhanced_serializer import FieldsetConfig, ModelExpansion
+except ImportError:
+    pass
 
 from flask_pydantic_api import pydantic_api
+
+pytestmark = [require_serializer]
 
 
 def test_validate_fieldsets() -> None:

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -5,11 +5,16 @@ from typing import ClassVar, Optional, Union
 import pytest
 from flask import Flask
 from pydantic import BaseModel
-from pydantic_enhanced_serializer import FieldsetConfig
 
 import flask_pydantic_api.apidocs_views
 from flask_pydantic_api import UploadedFile, pydantic_api
 from flask_pydantic_api.openapi import add_response_schema, get_openapi_schema
+from tests.utils import require_serializer
+
+try:  # Ensure pytest can parse the file without the import
+    from pydantic_enhanced_serializer import FieldsetConfig
+except ImportError:
+    pass
 
 
 @pytest.fixture
@@ -302,6 +307,7 @@ def test_path_args_keep(basic_app: Flask) -> None:
     assert "arg1" not in result["components"]["schemas"]["Body"]["properties"]
 
 
+@require_serializer
 def test_fieldsets_added_to_query_string(basic_app: Flask) -> None:
     class ResponseModel(BaseModel):
         field1: str
@@ -336,6 +342,7 @@ def test_fieldsets_added_to_query_string(basic_app: Flask) -> None:
     assert fields_field["schema"]["type"] == "string"
 
 
+@require_serializer
 def test_fieldsets_added_to_request_body(basic_app: Flask) -> None:
     class Body(BaseModel):
         field1: str

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,0 +1,14 @@
+import pytest
+
+has_enhanced_serializer: bool = False
+try:
+    import pydantic_enhanced_serializer  # noqa: F401
+    has_enhanced_serializer = True
+except ImportError:
+    pass
+
+
+require_serializer = pytest.mark.skipif(
+    not has_enhanced_serializer,
+    reason="Requires pydantic_enhanced_serializer"
+)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,8 @@
+[tox]
+env_list = py3{9,10,11,12,13}{,-serializer}
+
+[testenv]
+extras =
+    test
+    serializer: serializer
+commands = pytest --no-cov {posargs}


### PR DESCRIPTION
Hi 👋🏼 

This PR fixes multiple errors when using `flask-pydantic-api` without the `serializer` extra (like a the `NameError` raised when import `openapi.py`)

It also adds a `tox.ini` to be able to test against all supported Python versions, with and without the `serializer` extra (the monkey patching isn't enough has it doesn't detect import errors or anything relying on the serializer presence, the only way it to test without `pydantic-enhanced-serializer`)

> [!NOTE]
> You might want to add some GitHub Action CI as it is very hard to submit contribution safely. The `tox` test suite can easily be reused for that.


> [!NOTE]
> The `tox` testing also shows that it is broken for Python < 3.10, but due to the serializer. See https://github.com/adamsussman/pydantic-enhanced-serializer/pull/1