### PR TITLE
Fixed serializer import

### DIFF
--- a/flask_pydantic_api/openapi.py
+++ b/flask_pydantic_api/openapi.py
@@ -19,6 +19,7 @@ try:
         model_has_fieldsets_defined,
     )
 except ImportError:
+    FieldsetGenerateJsonSchema = None
     model_has_fieldsets_defined = None
 
 


### PR DESCRIPTION
```
Traceback (most recent call last):
  File "/opt/python/flask/app.py", line 1473, in wsgi_app
    response = self.full_dispatch_request()
               ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/flask/app.py", line 882, in full_dispatch_request
    rv = self.handle_user_exception(e)
         ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/flask_cors/extension.py", line 194, in wrapped_function
    return cors_after_request(app.make_response(f(*args, **kwargs)))
                                                ^^^^^^^^^^^^^^^^^^
  File "/opt/python/flask/app.py", line 880, in full_dispatch_request
    rv = self.dispatch_request()
         ^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/flask/app.py", line 865, in dispatch_request
    return self.ensure_sync(self.view_functions[rule.endpoint])(**view_args)  # type: ignore[no-any-return]
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/var/task/resources/admin/schema.py", line 11, in get_openapi_spec
    return get_openapi_schema()
           ^^^^^^^^^^^^^^^^^^^^
  File "/opt/python/flask_pydantic_api/openapi.py", line 293, in get_openapi_schema
    if schema_generator is None and FieldsetGenerateJsonSchema is not None:
                                    ^^^^^^^^^^^^^^^^^^^^^^^^^^
NameError: name 'FieldsetGenerateJsonSchema' is not defined
```