### PR TITLE
fix(serializer): Add all request types in a union to the requestBody schema

### DIFF
--- a/flask_pydantic_api/openapi.py
+++ b/flask_pydantic_api/openapi.py
@@ -99,9 +99,26 @@ def get_pydantic_api_path_operations(
                     request_body["description"] = " or ".join(
                         [request_body["description"], title]
                     )
-                    request_body["content"][content_type] = {
-                        "schema": {"$ref": f"#/components/schemas/{title}"}
-                    }
+
+                    if content_type in request_body["content"]:
+                        # There's a request body for this content type, add this to the union
+                        if (
+                            "oneOf"
+                            not in request_body["content"][content_type]["schema"]
+                        ):
+                            request_body["content"][content_type]["schema"] = {
+                                "oneOf": [
+                                    request_body["content"][content_type]["schema"]
+                                ]
+                            }
+
+                        request_body["content"][content_type]["schema"]["oneOf"].append(
+                            {"$ref": f"#/components/schemas/{title}"}
+                        )
+                    else:
+                        request_body["content"][content_type] = {
+                            "schema": {"$ref": f"#/components/schemas/{title}"}
+                        }
 
                 elif view_func_config.get_request_model_from_query_string:
                     request_body = {"schema": {"$ref": f"#/components/schemas/{title}"}}

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -553,6 +553,7 @@ def test_request_model_exploded_in_query_string() -> None:
     ]
     assert "Params" in result["components"]["schemas"]
 
+
 def test_union_request_same_content_type() -> None:
     class RequestA(BaseModel):
         field1: str
@@ -561,23 +562,23 @@ def test_union_request_same_content_type() -> None:
         field2: str
 
     app = Flask(import_name="test_app")
-    
-    @app.get(rule='/')
+
+    @app.get(rule="/")
     @pydantic_api()
     def do_work(request: Union[RequestA, RequestB]) -> Union[RequestA, RequestB]:
         return request
-    
+
     with app.app_context():
         result = get_openapi_schema()
-    
-    assert (
-        result["paths"]["/"]["get"]["requestBody"]["content"]["application/json"]["schema"] == {
-            "oneOf": [
-                {"$ref": "#/components/schemas/RequestA"},
-                {"$ref": "#/components/schemas/RequestB"}
-            ]
-        }
-    )
-        
+
+    assert result["paths"]["/"]["get"]["requestBody"]["content"]["application/json"][
+        "schema"
+    ] == {
+        "oneOf": [
+            {"$ref": "#/components/schemas/RequestA"},
+            {"$ref": "#/components/schemas/RequestB"},
+        ]
+    }
+
     assert "RequestA" in result["components"]["schemas"]
     assert "RequestB" in result["components"]["schemas"]

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -579,8 +579,11 @@ def test_union_request_same_content_type() -> None:
             {"$ref": "#/components/schemas/RequestB"},
         ]
     }
-    
-    assert result["paths"]["/"]["get"]["requestBody"]["description"] == "A RequestA or RequestB"
+
+    assert (
+        result["paths"]["/"]["get"]["requestBody"]["description"]
+        == "A RequestA or RequestB"
+    )
 
     assert "RequestA" in result["components"]["schemas"]
     assert "RequestB" in result["components"]["schemas"]
@@ -613,7 +616,10 @@ def test_union_request_different_content_type() -> None:
         "schema"
     ] == {"$ref": "#/components/schemas/MultipartFormDataRequest"}
 
-    assert result["paths"]["/"]["get"]["requestBody"]["description"] == "A ApplicationJsonRequest or MultipartFormDataRequest"
+    assert (
+        result["paths"]["/"]["get"]["requestBody"]["description"]
+        == "A ApplicationJsonRequest or MultipartFormDataRequest"
+    )
 
     assert "ApplicationJsonRequest" in result["components"]["schemas"]
     assert "MultipartFormDataRequest" in result["components"]["schemas"]
@@ -626,10 +632,16 @@ def test_union_request_multiple_mixed_content_types() -> None:
     class ApplicationJsonRequestB(BaseModel):
         field2: str
 
+    class ApplicationJsonRequestC(BaseModel):
+        field3: str
+
     class MultipartFormDataRequestA(BaseModel):
-        field3: UploadedFile
+        field1: UploadedFile
 
     class MultipartFormDataRequestB(BaseModel):
+        field2: UploadedFile
+
+    class MultipartFormDataRequestC(BaseModel):
         field3: UploadedFile
 
     app = Flask(import_name="test_app")
@@ -642,12 +654,16 @@ def test_union_request_multiple_mixed_content_types() -> None:
             MultipartFormDataRequestA,
             ApplicationJsonRequestB,
             MultipartFormDataRequestB,
+            ApplicationJsonRequestC,
+            MultipartFormDataRequestC,
         ]
     ) -> Union[
         ApplicationJsonRequestA,
         MultipartFormDataRequestA,
         ApplicationJsonRequestB,
         MultipartFormDataRequestB,
+        ApplicationJsonRequestC,
+        MultipartFormDataRequestC,
     ]:
         return request
 
@@ -660,6 +676,7 @@ def test_union_request_multiple_mixed_content_types() -> None:
         "oneOf": [
             {"$ref": "#/components/schemas/ApplicationJsonRequestA"},
             {"$ref": "#/components/schemas/ApplicationJsonRequestB"},
+            {"$ref": "#/components/schemas/ApplicationJsonRequestC"},
         ]
     }
 
@@ -669,12 +686,18 @@ def test_union_request_multiple_mixed_content_types() -> None:
         "oneOf": [
             {"$ref": "#/components/schemas/MultipartFormDataRequestA"},
             {"$ref": "#/components/schemas/MultipartFormDataRequestB"},
+            {"$ref": "#/components/schemas/MultipartFormDataRequestC"},
         ]
     }
 
-    assert result["paths"]["/"]["get"]["requestBody"]["description"] == "A ApplicationJsonRequestA or MultipartFormDataRequestA or ApplicationJsonRequestB or MultipartFormDataRequestB"
+    assert (
+        result["paths"]["/"]["get"]["requestBody"]["description"]
+        == "A ApplicationJsonRequestA or MultipartFormDataRequestA or ApplicationJsonRequestB or MultipartFormDataRequestB or ApplicationJsonRequestC or MultipartFormDataRequestC"
+    )
 
     assert "ApplicationJsonRequestA" in result["components"]["schemas"]
     assert "ApplicationJsonRequestB" in result["components"]["schemas"]
+    assert "ApplicationJsonRequestC" in result["components"]["schemas"]
     assert "MultipartFormDataRequestA" in result["components"]["schemas"]
     assert "MultipartFormDataRequestB" in result["components"]["schemas"]
+    assert "MultipartFormDataRequestC" in result["components"]["schemas"]

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -579,6 +579,8 @@ def test_union_request_same_content_type() -> None:
             {"$ref": "#/components/schemas/RequestB"},
         ]
     }
+    
+    assert result["paths"]["/"]["get"]["requestBody"]["description"] == "A RequestA or RequestB"
 
     assert "RequestA" in result["components"]["schemas"]
     assert "RequestB" in result["components"]["schemas"]
@@ -610,6 +612,8 @@ def test_union_request_different_content_type() -> None:
     assert result["paths"]["/"]["get"]["requestBody"]["content"]["multipart/form-data"][
         "schema"
     ] == {"$ref": "#/components/schemas/MultipartFormDataRequest"}
+
+    assert result["paths"]["/"]["get"]["requestBody"]["description"] == "A ApplicationJsonRequest or MultipartFormDataRequest"
 
     assert "ApplicationJsonRequest" in result["components"]["schemas"]
     assert "MultipartFormDataRequest" in result["components"]["schemas"]
@@ -667,6 +671,8 @@ def test_union_request_multiple_mixed_content_types() -> None:
             {"$ref": "#/components/schemas/MultipartFormDataRequestB"},
         ]
     }
+
+    assert result["paths"]["/"]["get"]["requestBody"]["description"] == "A ApplicationJsonRequestA or MultipartFormDataRequestA or ApplicationJsonRequestB or MultipartFormDataRequestB"
 
     assert "ApplicationJsonRequestA" in result["components"]["schemas"]
     assert "ApplicationJsonRequestB" in result["components"]["schemas"]


### PR DESCRIPTION
This PR fixes an issue where a request body with a `Union` type was only setting the last type in the union in the schema for a requestBody.

I went a little overboard on the tests out of an abundance of caution! I think just the `test_union_request_multiple_mixed_content_types` test would cover the conditions needed here if you want to pare them down.

I've verified that the emitted OpenApi JSON is valid with https://editor-next.swagger.io/

<details>
<summary>
the JSON emitted from `test_union_request_multiple_mixed_content_types`
</summary>

```json
{
  "openapi": "3.1.0",
  "info": {
    "title": "API Documentation",
    "version": "0.1"
  },
  "paths": {
    "/": {
      "get": {
        "tags": [],
        "parameters": [],
        "responses": {
          "200": {
            "description": "A ApplicationJsonRequestA or MultipartFormDataRequestA or ApplicationJsonRequestB or MultipartFormDataRequestB",
            "content": {
              "application/json": {
                "schema": {
                  "oneOf": [
                    {
                      "$ref": "#/components/schemas/ApplicationJsonRequestA"
                    },
                    {
                      "$ref": "#/components/schemas/MultipartFormDataRequestA"
                    },
                    {
                      "$ref": "#/components/schemas/ApplicationJsonRequestB"
                    },
                    {
                      "$ref": "#/components/schemas/MultipartFormDataRequestB"
                    }
                  ]
                }
              }
            }
          }
        },
        "requestBody": {
          "description": "A ApplicationJsonRequestA or MultipartFormDataRequestA or ApplicationJsonRequestB or MultipartFormDataRequestB",
          "content": {
            "application/json": {
              "schema": {
                "oneOf": [
                  {
                    "$ref": "#/components/schemas/ApplicationJsonRequestA"
                  },
                  {
                    "$ref": "#/components/schemas/ApplicationJsonRequestB"
                  }
                ]
              }
            },
            "multipart/form-data": {
              "schema": {
                "oneOf": [
                  {
                    "$ref": "#/components/schemas/MultipartFormDataRequestA"
                  },
                  {
                    "$ref": "#/components/schemas/MultipartFormDataRequestB"
                  }
                ]
              }
            }
          },
          "required": true
        }
      }
    }
  },
  "components": {
    "schemas": {
      "ApplicationJsonRequestA": {
        "properties": {
          "field1": {
            "title": "Field1",
            "type": "string"
          }
        },
        "required": [
          "field1"
        ],
        "title": "ApplicationJsonRequestA",
        "type": "object"
      },
      "MultipartFormDataRequestA": {
        "properties": {
          "field3": {
            "format": "binary",
            "title": "Field3",
            "type": "string"
          }
        },
        "required": [
          "field3"
        ],
        "title": "MultipartFormDataRequestA",
        "type": "object"
      },
      "ApplicationJsonRequestB": {
        "properties": {
          "field2": {
            "title": "Field2",
            "type": "string"
          }
        },
        "required": [
          "field2"
        ],
        "title": "ApplicationJsonRequestB",
        "type": "object"
      },
      "MultipartFormDataRequestB": {
        "properties": {
          "field3": {
            "format": "binary",
            "title": "Field3",
            "type": "string"
          }
        },
        "required": [
          "field3"
        ],
        "title": "MultipartFormDataRequestB",
        "type": "object"
      }
    }
  },
  "servers": [
    {
      "url": "/"
    }
  ]
}
```

</details>