### PR TITLE
fix(serializer): Treat `|` unions the same as `Union[...]`

### DIFF
--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -268,7 +268,8 @@ def test_union_response_object(basic_app: Flask) -> None:
         ]["schema"]["$ref"]
         == "#/components/schemas/ThisResponse"
     )
-    
+
+
 def test_union_type_response_object(basic_app: Flask) -> None:
     class ThisResponse(BaseModel):
         this_field1: str
@@ -292,7 +293,6 @@ def test_union_type_response_object(basic_app: Flask) -> None:
         ]["schema"]["$ref"]
         == "#/components/schemas/ThisResponse"
     )
-
 
 
 def test_path_args_merge(basic_app: Flask) -> None:
@@ -614,6 +614,7 @@ def test_model_and_uploader_request_body_with_union_type() -> None:
 
     assert "FileRequest" in result["components"]["schemas"]
     assert "OtherRequest" in result["components"]["schemas"]
+
 
 def test_request_model_exploded_in_query_string() -> None:
     class Params(BaseModel):

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -268,6 +268,31 @@ def test_union_response_object(basic_app: Flask) -> None:
         ]["schema"]["$ref"]
         == "#/components/schemas/ThisResponse"
     )
+    
+def test_union_type_response_object(basic_app: Flask) -> None:
+    class ThisResponse(BaseModel):
+        this_field1: str
+
+    @basic_app.get("/api/foo/bar")
+    @pydantic_api()
+    def get_something() -> dict | ThisResponse:
+        return {"field1": "bar"}
+
+    with basic_app.app_context():
+        result = get_openapi_schema()
+
+    assert "ThisResponse" in result["components"]["schemas"]
+    assert (
+        "this_field1" in result["components"]["schemas"]["ThisResponse"]["properties"]
+    )
+    assert "/api/foo/bar" in result["paths"]
+    assert (
+        result["paths"]["/api/foo/bar"]["get"]["responses"]["200"]["content"][
+            "application/json"
+        ]["schema"]["$ref"]
+        == "#/components/schemas/ThisResponse"
+    )
+
 
 
 def test_path_args_merge(basic_app: Flask) -> None:
@@ -486,6 +511,33 @@ def test_union_response_same_status_code() -> None:
     }
 
 
+def test_union_type_response_same_status_code() -> None:
+    class ResponseA(BaseModel):
+        field1: str
+
+    class ResponseB(BaseModel):
+        field2: str
+
+    app = Flask("test_app")
+
+    @app.get("/")
+    @pydantic_api()
+    def do_work() -> ResponseA | ResponseB:
+        return ResponseA(field1="val1")
+
+    with app.app_context():
+        result = get_openapi_schema()
+
+    assert result["paths"]["/"]["get"]["responses"]["200"]["content"][
+        "application/json"
+    ]["schema"] == {
+        "oneOf": [
+            {"$ref": "#/components/schemas/ResponseA"},
+            {"$ref": "#/components/schemas/ResponseB"},
+        ]
+    }
+
+
 def test_model_and_uploader_request_body() -> None:
     class FileRequest(BaseModel):
         file1: UploadedFile
@@ -524,6 +576,44 @@ def test_model_and_uploader_request_body() -> None:
     assert "FileRequest" in result["components"]["schemas"]
     assert "OtherRequest" in result["components"]["schemas"]
 
+
+def test_model_and_uploader_request_body_with_union_type() -> None:
+    class FileRequest(BaseModel):
+        file1: UploadedFile
+        other_var: str
+
+    class OtherRequest(BaseModel):
+        val1: str
+
+    app = Flask("test_app")
+
+    @app.post("/")
+    @pydantic_api()
+    def do_work(body: FileRequest | OtherRequest) -> dict:
+        return {}
+
+    with app.app_context():
+        result = get_openapi_schema()
+
+    assert result["paths"]["/"]["post"]["requestBody"] == {
+        "content": {
+            "application/json": {
+                "schema": {
+                    "$ref": "#/components/schemas/OtherRequest",
+                }
+            },
+            "multipart/form-data": {
+                "schema": {
+                    "$ref": "#/components/schemas/FileRequest",
+                }
+            },
+        },
+        "description": "A FileRequest or OtherRequest",
+        "required": True,
+    }
+
+    assert "FileRequest" in result["components"]["schemas"]
+    assert "OtherRequest" in result["components"]["schemas"]
 
 def test_request_model_exploded_in_query_string() -> None:
     class Params(BaseModel):


### PR DESCRIPTION
This PR adds support for the PEP 604 `UnionType`. It will allow users to type request or response unions as either `TypeA | TypeB` or `Union[TypeA, TypeB]` and get the expected result.

I wasn't able to figure out how to parametrize tests with unions so I duplicated some important looking ones.

The `is_union` function was taken from here: https://discuss.python.org/t/how-to-check-if-a-type-annotation-represents-an-union/77692/2