### PR TITLE
Allow type in path args

### DIFF
--- a/flask_pydantic_api/openapi.py
+++ b/flask_pydantic_api/openapi.py
@@ -30,7 +30,7 @@ except ImportError:
 PATH_PATTERN = re.compile(r"<(([^:<>]+):)?([\w_]+)>")
 """Match arguments in paths with optional type in match[1] and name in match[2]."""
 
-PATH_SCHEMA_MAP = {
+PATH_SCHEMA_MAP: Dict[Any, Dict[str, Any]] = {
     "string": {"type": "string"},
     "int": {"type": "integer", "minimum": 0},
     "int(signed=True)": {"type": "integer"},

--- a/flask_pydantic_api/openapi.py
+++ b/flask_pydantic_api/openapi.py
@@ -46,7 +46,7 @@ def get_pydantic_api_path_operations(
         if not rule.methods:
             continue
 
-        path = re.sub(r"<([\w_]+)>", "{\\1}", rule.rule)
+        path = re.sub(r"<([^:]+:)?([\w_]+)>", "{\\2}", rule.rule)
 
         parameters = []
         request_body: Optional[Dict[str, Any]] = None

--- a/flask_pydantic_api/openapi.py
+++ b/flask_pydantic_api/openapi.py
@@ -27,6 +27,18 @@ try:
 except ImportError:
     pass
 
+PATH_PATTERN = re.compile(r"<(([^:<>]+):)?([\w_]+)>")
+"""Match arguments in paths with optional type in match[1] and name in match[2]."""
+
+PATH_SCHEMA_MAP = {
+    "string": {"type": "string"},
+    "int": {"type": "integer", "minimum": 0},
+    "int(signed=True)": {"type": "integer"},
+    "float": {"type": "number"},
+    "path": {"type": "string", "format": "path"},
+}
+"""Map well known path argument types to JSON schema types."""
+
 
 def get_pydantic_api_path_operations(
     schema_generator: type[GenerateJsonSchema] = DEFAULT_SCHEMA_GENERATOR,
@@ -46,7 +58,10 @@ def get_pydantic_api_path_operations(
         if not rule.methods:
             continue
 
-        path = re.sub(r"<([^:]+:)?([\w_]+)>", "{\\2}", rule.rule)
+        path = re.sub(PATH_PATTERN, "{\\3}", rule.rule)
+        path_arg_types = {
+            match[2]: match[1] for match in PATH_PATTERN.findall(rule.rule)
+        }
 
         parameters = []
         request_body: Optional[Dict[str, Any]] = None
@@ -184,14 +199,14 @@ def get_pydantic_api_path_operations(
                 and name != request_model_param_name
                 and name != "return"
             ):
+                arg_type = path_arg_types.get(name)
+                schema = PATH_SCHEMA_MAP.get(arg_type, {"type": "string"})
                 parameters.append(
                     {
                         "name": name,
                         "in": "path",
                         "required": True,
-                        "schema": {
-                            "type": "string",
-                        },
+                        "schema": schema,
                     }
                 )
 

--- a/tests/test_openapi.py
+++ b/tests/test_openapi.py
@@ -332,6 +332,24 @@ def test_path_args_keep(basic_app: Flask) -> None:
     assert "arg1" not in result["components"]["schemas"]["Body"]["properties"]
 
 
+def test_path_args_typed(basic_app: Flask) -> None:
+    class Body(BaseModel):
+        field1: str
+
+    @basic_app.get("/foo/<int:arg1>")
+    @pydantic_api()
+    def get_foo(arg1: str, body: Body) -> Body:
+        return body
+
+    with basic_app.app_context():
+        result = get_openapi_schema()
+
+    assert "arg1" in [
+        param["name"] for param in result["paths"]["/foo/{arg1}"]["get"]["parameters"]
+    ]
+    assert "arg1" not in result["components"]["schemas"]["Body"]["properties"]
+
+
 @require_serializer
 def test_fieldsets_added_to_query_string(basic_app: Flask) -> None:
     class ResponseModel(BaseModel):


### PR DESCRIPTION
Currently the openapi generator blows up if there is a Flask type-spec on a path parameter such as in `/resource/<int:id>` so we have to remove those from the paths and Flask will send all path arguments in as strings.

This change a) expands the regular expression so it allows any form of `<int:var_name>` or `<type_spec(arg=value):var_name>` that I can think of and if the type is from a short list of well-known ones, then it gets translated to a JSON schema instead of the default string schema.

![image](https://github.com/user-attachments/assets/39312f62-905a-43ba-b97c-7219d3a10288)

The list of types is clearly not exhaustive, nor can it probably ever be, but it is better than nothing and can be expanded from here.